### PR TITLE
bump runtime-version to 3.36

### DIFF
--- a/net.bartkessels.getit.json
+++ b/net.bartkessels.getit.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "net.bartkessels.getit",
 	"runtime": "org.gnome.Platform",
-	"runtime-version": "3.32",
+	"runtime-version": "3.36",
 	"sdk": "org.gnome.Sdk",
 	"command": "getit",
 	"finish-args": [


### PR DESCRIPTION
solves the warning about deprecated 3.32