### PR TITLE
add device=dri for wayland-egl

### DIFF
--- a/net.bartkessels.getit.json
+++ b/net.bartkessels.getit.json
@@ -8,6 +8,7 @@
 		"--socket=x11",
 		"--share=ipc",
 		"--socket=wayland",
+		"--device=dri",
 		"--share=network"
 	],
 	"cleanup": [


### PR DESCRIPTION
Addresses the output seen when launched from terminal:
```
$ flatpak run net.bartkessels.getit
libEGL warning: wayland-egl: could not open /dev/dri/renderD128 (No such file or directory)
libEGL warning: wayland-egl: could not open /dev/dri/renderD128 (No such file or directory)
```