### PR TITLE
Bump runtime to 42

### DIFF
--- a/net.bartkessels.getit.json
+++ b/net.bartkessels.getit.json
@@ -1,7 +1,7 @@
 {
 	"app-id": "net.bartkessels.getit",
 	"runtime": "org.gnome.Platform",
-	"runtime-version": "40",
+	"runtime-version": "42",
 	"sdk": "org.gnome.Sdk",
 	"command": "getit",
 	"finish-args": [


### PR DESCRIPTION
Hello, I saw that v5.0.0 was rewritten in Qt from GTK. So I didn't update the release. I also saw there was an issue about releasing it to Flathub. Let me know if 5.0.0 is shippable and you want to convert this to depend on org.kde.Platform/freedesktop instead for the newest release. Thanks!

cc @bartkessels